### PR TITLE
Add compatibility with Rails 3.2

### DIFF
--- a/lib/rails-settings/settings.rb
+++ b/lib/rails-settings/settings.rb
@@ -2,6 +2,7 @@ module RailsSettings
   class Settings < ActiveRecord::Base
 
     self.table_name = 'settings'
+    attr_accessible :var
 
     class SettingNotFound < RuntimeError; end
 


### PR DESCRIPTION
The current master branch leads to a mass-assignment error when you try to update a setting because the `var` variable is not `attr_accessible`.

In this pull request, I've simply made `RailsSettings::Settings` sort this out for you. No other changes are needed, as far as I can tell.

Version numbers still need bumping and stuff.
